### PR TITLE
change frequencies_to_stop_times function to allow proper routing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,10 @@ Authors@R: c(
             role=c("aut", "cre")),
     person(given = "Marcin", family = "Stepniak",
            email = "marcinstepniak@ucm.es",
-           role = "aut", comment = c(ORCID = "0000-0002-6489-5443")))
+           role = "aut", comment = c(ORCID = "0000-0002-6489-5443")),
+    person(given = "Alexandra", family = "Kapp",
+            email = "alk@mobilityinstitute.com",
+            role = "ctb"))
 Description: Use GTFS (General Transit Feed Specification) data for routing from
     nominated start and end stations, and for extracting isochrones from
     nominated start station.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gtfsrouter
 Title: Routing with GTFS (General Transit Feed Specification) Data
-Version: 0.0.1.015
+Version: 0.0.1.016
 Authors@R: c(
     person("Mark", "Padgham",
             email="mark.padgham@email.com",

--- a/R/frequencies_to_stop_times.R
+++ b/R/frequencies_to_stop_times.R
@@ -112,16 +112,13 @@ frequencies_to_stop_times <- function(gtfs)
     
     gtfs_cp$stop_times <- rbind (gtfs_cp$stop_times [!(trip_id) %in% gtfs_cp$frequencies$trip_id], stop_times)
     
-    gtfs_cp$trips <- gtfs_cp$stop_times %>%
-      select(trip_id, trip_id_f) %>%
-      distinct(trip_id_f, .keep_all = T) %>%
-      left_join(gtfs_cp$trips, by = c("trip_id" = "trip_id")) %>%
-      select(-trip_id) %>%
-      rename(trip_id = trip_id_f)
+    trip_id_mapping <- unique(gtfs_cp$stop_times [, c("trip_id", "trip_id_f")])
+    gtfs_cp$trips <- merge(gtfs_cp$trips, trip_id_mapping, by = "trip_id", all.y = T)
+    gtfs_cp$trips$trip_id <- gtfs_cp$trips$trip_id_f
+    gtfs_cp$trips <- subset(gtfs_cp$trips, select= names(gtfs_cp$trips) != "trip_id_f") # rm trip_id_f
     
-    gtfs_cp$stop_times <- gtfs_cp$stop_times %>%
-      select(-trip_id) %>%
-      rename(trip_id = trip_id_f)
+    gtfs_cp$stop_times$trip_id <- gtfs_cp$stop_times$trip_id_f
+    gtfs_cp$stop_times <- subset(gtfs_cp$stop_times, select= names(gtfs_cp$stop_times) != "trip_id_f") # rm trip_id_f
     
     return (gtfs_cp)
 }

--- a/R/frequencies_to_stop_times.R
+++ b/R/frequencies_to_stop_times.R
@@ -112,5 +112,16 @@ frequencies_to_stop_times <- function(gtfs)
     
     gtfs_cp$stop_times <- rbind (gtfs_cp$stop_times [!(trip_id) %in% gtfs_cp$frequencies$trip_id], stop_times)
     
+    gtfs_cp$trips <- gtfs_cp$stop_times %>%
+      select(trip_id, trip_id_f) %>%
+      distinct(trip_id_f, .keep_all = T) %>%
+      left_join(gtfs_cp$trips, by = c("trip_id" = "trip_id")) %>%
+      select(-trip_id) %>%
+      rename(trip_id = trip_id_f)
+    
+    gtfs_cp$stop_times <- gtfs_cp$stop_times %>%
+      select(-trip_id) %>%
+      rename(trip_id = trip_id_f)
+    
     return (gtfs_cp)
 }

--- a/tests/testthat/test-frequencies.R
+++ b/tests/testthat/test-frequencies.R
@@ -186,7 +186,7 @@ test_that("gtfs frequencies in gtfs_route", {
   
   #undebug(frequencies_to_stop_times)
   gtfs_freq <- frequencies_to_stop_times(gtfs)
-  gtfs_timetable <- gtfs_timetable(gtfs_freq, day = "Sunday")
+  gtfs_timetable <- gtfs_timetable(gtfs_freq, day = "Monday")
   r <- gtfs_route(gtfs_timetable, "Warschauer", "Prinzenstr", start_time = 8 * 3600 + 10*60)
   
   expect_equal(r[1, "arrival_time"], "08:10:00")

--- a/tests/testthat/test-frequencies.R
+++ b/tests/testthat/test-frequencies.R
@@ -148,7 +148,7 @@ test_that ("gtfs with mixed frequencies", {
                  nrow(gtfs_freq4$stop_times[trip_id %in% trips_U3$trip_id]))
     # line with frequencies should have stop_times multiplied
     expect_lt(nrow(gtfs$stop_times[trip_id == sel_trip_id_U1]),
-              nrow(gtfs_freq4$stop_times[trip_id == sel_trip_id_U1]))
+              nrow(gtfs_freq4$stop_times[grepl(sel_trip_id_U1, trip_id)]))
 })
 
 test_that("gtfs frequencies in gtfs_route", {
@@ -184,7 +184,6 @@ test_that("gtfs frequencies in gtfs_route", {
     end_time = "09:00:00",
     headway_secs = 10 * 60)
   
-  #undebug(frequencies_to_stop_times)
   gtfs_freq <- frequencies_to_stop_times(gtfs)
   gtfs_timetable <- gtfs_timetable(gtfs_freq, day = "Monday")
   r <- gtfs_route(gtfs_timetable, "Warschauer", "Prinzenstr", start_time = 8 * 3600 + 10*60)

--- a/tests/testthat/test-frequencies.R
+++ b/tests/testthat/test-frequencies.R
@@ -150,3 +150,45 @@ test_that ("gtfs with mixed frequencies", {
     expect_lt(nrow(gtfs$stop_times[trip_id == sel_trip_id_U1]),
               nrow(gtfs_freq4$stop_times[trip_id == sel_trip_id_U1]))
 })
+
+test_that("gtfs frequencies in gtfs_route", {
+  berlin_gtfs_to_zip()
+  f <- file.path(tempdir(), "vbb.zip")
+  expect_true(file.exists(f))
+  gtfs <- extract_gtfs(f)
+  
+  gtfs$routes <- gtfs$routes[route_short_name %in% c("U1", "U6")]
+  
+  # select only one route wich runs on mondays
+  trips_U1 <- gtfs$trips [(route_id %in% gtfs$routes[route_short_name == "U1"][["route_id"]] )
+                          & (service_id %in% gtfs$calendar[monday == "1"][["service_id"]])]
+  
+  sel_trip_id_U1 <- head(gtfs$stop_times [trip_id %in% trips_U1$trip_id,
+                                          .N,
+                                          by = "trip_id"
+  ][N == max(N), trip_id], 1)
+  
+  gtfs$trips <- gtfs$trips[trip_id %in% c(sel_trip_id_U1)]
+  
+  gtfs$calendar <- gtfs$calendar[service_id %in% gtfs$trips$service_id]
+  gtfs$stop_times <- gtfs$stop_times[trip_id %in% gtfs$trips$trip_id]
+  gtfs$stops <- gtfs$stops[stop_id %in% gtfs$stop_times$stop_id]
+  
+  gtfs$transfers <- gtfs$transfers[from_stop_id %in% gtfs$stops$stop_id &
+                                     to_stop_id %in% gtfs$stops$stop_id]
+  
+  # create frequencies for the route U1
+  gtfs$frequencies <- data.table::data.table(
+    trip_id = sel_trip_id_U1[1],
+    start_time = "08:00:00",
+    end_time = "09:00:00",
+    headway_secs = 10 * 60)
+  
+  #undebug(frequencies_to_stop_times)
+  gtfs_freq <- frequencies_to_stop_times(gtfs)
+  gtfs_timetable <- gtfs_timetable(gtfs_freq, day = "Sunday")
+  r <- gtfs_route(gtfs_timetable, "Warschauer", "Prinzenstr", start_time = 8 * 3600 + 10*60)
+  
+  expect_equal(r[1, "arrival_time"], "08:10:00")
+  expect_equal(r[nrow(r), "arrival_time"], "08:17:30")
+})


### PR DESCRIPTION
Issue: the function `frequencies_to_stop_times` does not update the trip_ids in `trips.txt` and `stop_times.txt`.
Therefore, the routing with `gtfs_route `does not work properly.

Routing result before:
![grafik](https://user-images.githubusercontent.com/18367515/87765390-082a9480-c818-11ea-8384-26180eae7fc2.png)

With fix:
![grafik](https://user-images.githubusercontent.com/18367515/87765518-327c5200-c818-11ea-8bb2-be94ed5cf6dc.png)
