### PR TITLE
Timetable day and date combined

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gtfsrouter
 Title: Routing with GTFS (General Transit Feed Specification)
     Data
-Version: 0.0.3.005
+Version: 0.0.3.006
 Authors@R: 
     c(person(given = "Mark",
              family = "Padgham",

--- a/man/gtfs_timetable.Rd
+++ b/man/gtfs_timetable.Rd
@@ -23,7 +23,10 @@ used - unless the following 'date' parameter is give.}
 \item{date}{Some systems do not specify days of the week within their
 'calendar' table; rather they provide full timetables for specified calendar
 dates via a 'calendar_date' table. Providing a date here as a single 8-digit
-number representing 'yyyymmdd' will filter the data to the specified date.}
+number representing 'yyyymmdd' will filter the data to the specified date.
+Also the 'calendar' is scanned for services that operate
+on the selected date. Therefore also a merge of feeds that combine 'calendar'
+and 'calendar_dates' options is covered.}
 
 \item{route_pattern}{Using only those routes matching given pattern, for
 example, "^U" for routes starting with "U" (as commonly used for underground


### PR DESCRIPTION
- when "date" option is chosen for timetable construction (e.g.  `get_timetable(gtfs, date=20200925)`  also add `calendar.txt` is scanned for valid entries
- necessary especially for feeds where two feeds are merged where one uses the "calendar" option and the other the "calendar_dates" option

@mpadge I adjusted the `filter_by_date`function, as I couldnt think of a usecase where the old version would be needed without the inclusion of the "calendar" entries. Though this could lead to different results for people who used the function before and which would now have a different behavior. 
Therefore I was considering to add a parameter "scan_day_for_date = FALSE" to the `get_timetable()` function that is then passed to `filter_by_date.`