### PR TITLE
Fixes README github repo name

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -28,7 +28,7 @@ remotes::install_git ("https://git.sr.ht/~mpadge/gtfsrouter")
 remotes::install_git ("https://codeberg.org/ATFutures/gtfsrouter")
 remotes::install_bitbucket ("atfutures/gtfsrouter")
 remotes::install_gitlab ("atfutures1/gtfsrouter")
-remotes::install_github ("ATFutures/gtfsrouter")
+remotes::install_github ("ATFutures/gtfs-router")
 ```
 
 To load the package and check the version:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ remotes::install_git ("https://git.sr.ht/~mpadge/gtfsrouter")
 remotes::install_git ("https://codeberg.org/ATFutures/gtfsrouter")
 remotes::install_bitbucket ("atfutures/gtfsrouter")
 remotes::install_gitlab ("atfutures1/gtfsrouter")
-remotes::install_github ("ATFutures/gtfsrouter")
+remotes::install_github ("ATFutures/gtfs-router")
 ```
 
 To load the package and check the version:


### PR DESCRIPTION
I tried installing the dev version using the `install_github()` call in the repo but it failed because the repo name was misspelled. This commit fixes this issue.

PS: I haven't tested the other `install_...` calls.